### PR TITLE
Fixed update user roles

### DIFF
--- a/src/main/java/com/revature/controllers/AuthController.java
+++ b/src/main/java/com/revature/controllers/AuthController.java
@@ -234,12 +234,15 @@ public class AuthController {
 	@PreAuthorize("hasRole('ADMIN')")
 	@PutMapping(value = "/id", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
 	@ResponseStatus(HttpStatus.OK)
-	public AppUser updateToAdmin(@RequestBody AppUser user, Authentication auth) {
+	public AppUser updateUserRole(@RequestBody AppUser user, Authentication auth) {
 		System.out.println("in update to Admin");
 		AppUser user1 = userService.findById(user.getId());
 		System.out.println(user.getId());
 		if(user1 == null) { throw new UserNotFoundException("user with id: " +user.getId() +", not found"); }
-		user.setRole("ROLE_ADMIN");
+		
+		System.out.println("User Role: " + user.getRole());
+		System.out.println("User1 Role: " + user1.getRole());
+		System.out.println(user.getRole());
 		userService.updateUser(user);
 		return user;
 		

--- a/src/main/java/com/revature/controllers/AuthController.java
+++ b/src/main/java/com/revature/controllers/AuthController.java
@@ -1,6 +1,8 @@
 package com.revature.controllers;
 
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.validation.Valid;
 
@@ -50,6 +52,8 @@ import com.revature.services.UserService;
 @RequestMapping("/users")
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 public class AuthController {
+	
+	private static Logger log = Logger.getLogger("DRIVER_LOGGER");
 
 	private UserService userService;
 
@@ -240,9 +244,9 @@ public class AuthController {
 		System.out.println(user.getId());
 		if(user1 == null) { throw new UserNotFoundException("user with id: " +user.getId() +", not found"); }
 		
-		System.out.println("User Role: " + user.getRole());
-		System.out.println("User1 Role: " + user1.getRole());
-		System.out.println(user.getRole());
+		log.log(Level.INFO, "User Role: " + user.getRole());
+		log.log(Level.INFO, "User1 Role: " + user1.getRole());
+		log.log(Level.INFO, user.getRole());
 		userService.updateUser(user);
 		return user;
 		

--- a/src/test/java/com/revature/controllers/AuthControllerTest.java
+++ b/src/test/java/com/revature/controllers/AuthControllerTest.java
@@ -302,7 +302,7 @@ public class AuthControllerTest {
 		when(userService.findById(1)).thenReturn(mockedPersistedAdmin);
 		when(userService.updateUser(mockedUserForUpdate)).thenReturn(true);
 
-		AppUser testResult = authController.updateToAdmin(mockedUserForUpdate, mockAuth);
+		AppUser testResult = authController.updateUserRole(mockedUserForUpdate, mockAuth);
 		verify(userService, times(1)).updateUser(mockedUserForUpdate);
 		assertNotNull("The AppUser returned is expected to be not null", testResult);
 		assertEquals("The AppUser returned is expected to match the mocked one", expectedResult, testResult);


### PR DESCRIPTION
This feature initially changed a user to admin, but couldn't change back to a user if needed.
This was fixed in this PR